### PR TITLE
Update config.nix to enable nvidia by default

### DIFF
--- a/hosts/default/config.nix
+++ b/hosts/default/config.nix
@@ -104,7 +104,7 @@
   # Extra Module Options
   drivers.amdgpu.enable = true;
   drivers.intel.enable = true;
-  drivers.nvidia.enable = false;
+  drivers.nvidia.enable = true;
   drivers.nvidia-prime = {
     enable = false;
     intelBusID = "";


### PR DESCRIPTION
Enable nvidia by default.  The Intel and AMD are enabled by default.

# Pull Request

## Description

Please read these instructions and remove unnecessary text.
Currently only AMD and Intel graphics adapters are enabled.  If using autoinstall.sh or install.sh after the initial build/reboot GUI won't work for NVIDIA users 

## Type of change

Please put an `x` in the boxes that apply:

- [ X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X ] My code follows the code style of this project.
- [X ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in NixOS-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context
 at the moment don't have NVIDIA system to test with.  I can't see where enabling the driver for systems w/o NVIDIA would be impacted. 
